### PR TITLE
Fix issue stemming from using resource name instead of slug name

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -116,13 +116,13 @@ var Localize = {
     callback();
   },
   resourcesUrl:function(){
-    return this.API_ENDPOINT + $('#project_name').val() + '/resources/';
+    return encodeURI(this.API_ENDPOINT + $('#project_name').val() + '/resources/');
   },
   availableLanguagesUrl: function(){
-    return this.API_ENDPOINT + $('#project_name').val() + '/resource/' + $('#resource_name').val() + '/?details'
+    return encodeURI(this.API_ENDPOINT + $('#project_name').val() + '/resource/' + $('#resource_name').val() + '/?details');
   },
   stringsUrl: function(language) {
-    return this.API_ENDPOINT + $('#project_name').val() + '/resource/' + $('#resource_name').val() + '/translation/' + language + '/strings/';
+    return encodeURI(this.API_ENDPOINT + $('#project_name').val() + '/resource/' + $('#resource_name').val() + '/translation/' + language + '/strings/');
   },
   getResourceNames: function() {
     $('#resource_name').val('');
@@ -133,7 +133,7 @@ var Localize = {
         this.resourceNames = [];
         var slugNames = data;
         $.each(slugNames, $.proxy(function(i, item){
-              this.resourceNames.push(slugNames[i].name);
+            this.resourceNames.push({name: slugNames[i].name, slugname: slugNames[i].slug});
             }, this));
         this.onSuccess($.proxy(this.populateResourceNames, this));
       }, this),
@@ -145,8 +145,8 @@ var Localize = {
   },
   populateResourceNames: function(){
     $('#resource_name').html('');
-    for(i=0; i <= this.resourceNames.length; i++){
-      $('#resource_name').append('<option>' + this.resourceNames[i] + '</option>');
+    for(i=0; i < this.resourceNames.length; i++){
+      $('#resource_name').append('<option value="' + this.resourceNames[i].slugname + '">' + this.resourceNames[i].name + '</option>');
     }
     console.log('resource names populated');
   },
@@ -219,7 +219,7 @@ var Localize = {
       return languages;
     },
 
-    generateKeyList: function() { //onclick from "Get strangs" button above
+    generateKeyList: function() { //onclick from "Get strings" button above
       $('#trans').html("");
       //Generate clickable keys
       $.each(Localize.translated['en'], $.proxy(function(index, translated) {

--- a/script.jsx
+++ b/script.jsx
@@ -1,1 +1,31 @@
-﻿var doc = app.activeDocument;/*******ENTER STRINGS HERE*************/var to_rename = prompt("Which layer do you want to localize?", "");var getStrings = prompt("Enter translated strings:", '');/*******ENTER STRINGS HERE*************/var langs = eval("(" + getStrings + ")");var Name = app.activeDocument.name.replace(/\.[^\.]+$/, '');var textLayer = doc.artLayers.getByName(to_rename);if(app.documents.length != 0){      for (var langKey in langs) {        var to_dup = textLayer.duplicate();        to_dup.name += "-" + langKey;        to_dup.textItem.contents = langs[langKey];        to_dup.name = to_dup.name.replace(" copy", "");    }}function renameLayer(objectRef) {	var theRegEx = new RegExp(/(\s*copy\s*\d*)+$/);	if (theRegEx.test(objectRef.name)) {		// save state of layer (visible or invisible)		var layerVisible = objectRef.visible;		var indexNumber = 0;		indexnumber = objectRef.name.indexOf("_" + langArr[i]);		objectRef.name = objectRef.name.substr(0,indexnumber);		objectRef.visible = layerVisible;	}	return 0;}
+﻿var doc = app.activeDocument;
+
+/*******ENTER STRINGS HERE*************/
+var to_rename = prompt("Which layer do you want to localize?", "");
+var getStrings = prompt("Enter translated strings:", '');
+/*******ENTER STRINGS HERE*************/
+var langs = eval("(" + getStrings + ")");
+var Name = app.activeDocument.name.replace(/\.[^\.]+$/, '');
+
+var textLayer = doc.artLayers.getByName(to_rename);
+if(app.documents.length != 0){  
+    for (var langKey in langs) {
+        var to_dup = textLayer.duplicate();
+        to_dup.name += "-" + langKey;
+        to_dup.textItem.contents = langs[langKey];
+        to_dup.name = to_dup.name.replace(" copy", "");
+    }
+}
+function renameLayer(objectRef) {
+    var theRegEx = new RegExp(/(\s*copy\s*\d*)+$/);
+    if (theRegEx.test(objectRef.name)) {
+        // save state of layer (visible or invisible)
+        var layerVisible = objectRef.visible;
+        var indexNumber = 0;
+
+        indexnumber = objectRef.name.indexOf("_" + langArr[i]);
+        objectRef.name = objectRef.name.substr(0,indexnumber);
+        objectRef.visible = layerVisible;
+    }
+    return 0;
+}


### PR DESCRIPTION
In the URL, the resource name was used instead of the slug name. Maybe the API changed or it worked on some resources, but I had a resource with a space in its name and that didn't work. To counter that I added `encodeUI` which shouldn't hurt anyway but mostly I use the `slug` sent back by the API.

I also changed the line endings to Unix on the `.jsx` file. That could be argued against I imagine, but it didn't let me open the file properly in my editor with Windows line endings…
